### PR TITLE
 improved version with static peers in .env

### DIFF
--- a/common/scripts/prepare_docker_functions.sh
+++ b/common/scripts/prepare_docker_functions.sh
@@ -287,3 +287,34 @@ stop_node () {
 show_logs () {
   docker compose logs -f --tail 1000
 }
+
+generate_peering_json() {
+  local peeringFilePath="$1"
+  local staticNeighbors="$2"
+
+  if [ -z "$staticNeighbors" ]; then
+    echo -e "No static neighbors defined"
+    jq -n '{peers: []}' > "$peeringFilePath"
+    return
+  fi
+  echo "Generating peering.json..."
+  local peersJson="[]"
+  IFS=','
+  for neighbor in $staticNeighbors; do
+    local cleanedNeighbor=$(echo "$neighbor" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    local alias=""
+    local multiAddress=""
+
+    if [[ "$cleanedNeighbor" =~ .*:.* ]]; then
+        alias=$(echo "$cleanedNeighbor" | cut -d ':' -f 1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        multiAddress=$(echo "$cleanedNeighbor" | cut -d ':' -f 2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    else
+        alias="Node-$(date +%s%N | sha256sum | head -c 8)"
+        multiAddress="$cleanedNeighbor"
+    fi
+
+    peersJson=$(jq --arg alias "$alias" --arg multiAddress "$multiAddress" '. += [{"alias": $alias, "multiAddress": $multiAddress}]' <<< "$peersJson")
+  done
+  unset IFS
+  echo "$peersJson" | jq '{peers: .}' > "$peeringFilePath" && echo "${peeringFilePath} successfully generated" || echo "Failed to generate peering.json"
+}

--- a/iota-hornet/docker-compose.yml
+++ b/iota-hornet/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "${HORNET_DATA_DIR:-./data}/config/config-${HORNET_NETWORK:-mainnet}.json:/app/config/config.json:ro"
+      - "${HORNET_DATA_DIR:-./data}/config/peering-${HORNET_NETWORK:-mainnet}.json:/app/config/peering.json"
       - "${HORNET_DATA_DIR:-./data}/storage/${HORNET_NETWORK:-mainnet}:/app/storage"
       - "${HORNET_DATA_DIR:-./data}/snapshots/${HORNET_NETWORK:-mainnet}:/app/snapshots"
       - "${HORNET_DATA_DIR:-./data}/p2pstore/${HORNET_NETWORK:-mainnet}:/app/p2pstore"

--- a/iota-hornet/prepare_docker.sh
+++ b/iota-hornet/prepare_docker.sh
@@ -12,6 +12,9 @@ dataDir="${HORNET_DATA_DIR:-$scriptDir/data}"
 configFilenameInContainer="config.json"
 configFilename="config-${HORNET_NETWORK:-mainnet}.json"
 configPath="${dataDir}/config/${configFilename}"
+peeringFilenameInContainer="peering.json"
+peeringFilename="peering-${HORNET_NETWORK:-mainnet}.json"
+peeringFilePath="${dataDir}/config/${peeringFilename}"
 
 validate_ssl_config "HORNET_SSL_CERT" "HORNET_SSL_KEY"
 copy_common_assets
@@ -66,6 +69,7 @@ set_config_if_present_in_env "${configPath}" "HORNET_PRUNING_MAX_MILESTONES_TO_K
 if [ ! -z "${HORNET_PRUNING_MAX_MILESTONES_TO_KEEP}" ]; then
   set_config "${configPath}" ".pruning.milestones.enabled" "true"
 fi
+generate_peering_json "$peeringFilePath" "${HORNET_STATIC_NEIGHBORS:-""}"
 rm -f "${tmp}"
 
 echo "Finished"

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -2644,21 +2644,58 @@ IotaHornet() {
 		VAR_IOTA_HORNET_AUTOPEERING=$(cat .env 2>/dev/null | grep HORNET_AUTOPEERING_ENABLED= | cut -d '=' -f 2)
 		VAR_DEFAULT='true'
 		if [ -z "$VAR_IOTA_HORNET_AUTOPEERING" ]; then
-		  echo "Set autopeering (default: $ca"$VAR_DEFAULT"$xx):"; echo "Press [Enter] to use default value:"; else echo "Set autopeering (config: $ca""$VAR_IOTA_HORNET_AUTOPEERING""$xx)"; echo "Press [Enter] to use existing config:"; fi
-		read -r -p '> Press [A] to enable autopeering... Press [X] key to disable... ' VAR_TMP;
-		if [ -n "$VAR_TMP" ]; then
+		  echo "Set autopeering (default: $ca$VAR_DEFAULT$xx):"; echo "Press [Enter] to use default value:"
+		else
+		  echo "Set autopeering (config: $ca$VAR_IOTA_HORNET_AUTOPEERING$xx)"; echo "Press [Enter] to use existing config:"
+		fi
+		read -r -p '> Press [E] to enable Autopeering... Press [X] key to disable... ' VAR_TMP;
+        if [ -n "$VAR_TMP" ]; then
 		  VAR_IOTA_HORNET_AUTOPEERING=$VAR_TMP
-		  if  [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'a' ] || [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'A' ]; then
+		  if  [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'e' ] || [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'E' ]; then
 		    VAR_IOTA_HORNET_AUTOPEERING='true'
 		  else
 		    VAR_IOTA_HORNET_AUTOPEERING='false'
-		  fi
+		fi
 		elif [ -z "$VAR_IOTA_HORNET_AUTOPEERING" ]; then VAR_IOTA_HORNET_AUTOPEERING=$VAR_DEFAULT; fi
 
-		if  [ "$VAR_IOTA_HORNET_AUTOPEERING" ]; then
+		if  [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'true'  ]; then
 		  echo "$gn""Set autopeering: $VAR_IOTA_HORNET_AUTOPEERING""$xx"
 		else
 		  echo "$rd""Set autopeering: $VAR_IOTA_HORNET_AUTOPEERING""$xx"
+		fi
+
+		if [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'false' ]; then
+		  echo ''
+		  VAR_DEFAULT_STATIC_NEIGHBORS=''
+		  VAR_IOTA_HORNET_STATIC_NEIGHBORS=$(cat .env 2>/dev/null | grep HORNET_STATIC_NEIGHBORS= | cut -d '=' -f 2)
+			
+		  if [ -n "$VAR_IOTA_HORNET_STATIC_NEIGHBORS" ]; then
+		    echo "Set static neighbor(s):"
+		    echo "(config: static neighbor(s):"
+		    echo "$ca""$VAR_IOTA_HORNET_STATIC_NEIGHBORS""$xx" | tr ',' '\n'
+		    echo ')'
+		    echo ''
+		    echo "Press [Enter] to confirm the above static neighbors or enter new ones (alias:multiAddress,):"
+		    read -r STATIC_NEIGHBORS_INPUT
+		  else
+		    echo "Set static neighbor(s):"
+		    echo "No static neighbors configured. Please enter static neighbors (alias:multiAddress,):"
+		    read -r STATIC_NEIGHBORS_INPUT
+		  fi
+
+		  STATIC_NEIGHBORS_INPUT=$(echo "$STATIC_NEIGHBORS_INPUT" | tr -d ' ')
+
+		  if [ -n "$STATIC_NEIGHBORS_INPUT" ]; then
+		    VAR_IOTA_HORNET_STATIC_NEIGHBORS=$STATIC_NEIGHBORS_INPUT
+		  elif [ -z "$VAR_IOTA_HORNET_STATIC_NEIGHBORS" ]; then
+		    VAR_IOTA_HORNET_STATIC_NEIGHBORS=$VAR_DEFAULT_STATIC_NEIGHBORS
+		  fi
+
+		  if [ -n "$VAR_IOTA_HORNET_STATIC_NEIGHBORS" ]; then
+		    echo ''
+		    echo "New static neighbor(s):"
+		    echo "$gn""$VAR_IOTA_HORNET_STATIC_NEIGHBORS""$xx" | tr ',' '\n'
+		  fi
 		fi
 
 		echo ''
@@ -2713,6 +2750,7 @@ IotaHornet() {
 		echo "HORNET_HTTPS_PORT=$VAR_IOTA_HORNET_HTTPS_PORT" >> .env
 		echo "HORNET_GOSSIP_PORT=15600" >> .env
 		echo "HORNET_AUTOPEERING_ENABLED=$VAR_IOTA_HORNET_AUTOPEERING" >> .env
+		echo "HORNET_STATIC_NEIGHBORS=$VAR_IOTA_HORNET_STATIC_NEIGHBORS" >> .env
 		echo "HORNET_AUTOPEERING_PORT=14626" >> .env
 		echo "RESTAPI_SALT=$VAR_SALT" >> .env
 
@@ -3431,21 +3469,56 @@ ShimmerHornet() {
 		VAR_SHIMMER_HORNET_AUTOPEERING=$(cat .env 2>/dev/null | grep HORNET_AUTOPEERING_ENABLED= | cut -d '=' -f 2)
 		VAR_DEFAULT='true'
 		if [ -z "$VAR_SHIMMER_HORNET_AUTOPEERING" ]; then
-		  echo "Set autopeering (default: $ca"$VAR_DEFAULT"$xx):"; echo "Press [Enter] to use default value:"; else echo "Set autopeering (config: $ca""$VAR_SHIMMER_HORNET_AUTOPEERING""$xx)"; echo "Press [Enter] to use existing config:"; fi
-		read -r -p '> Press [A] to enable autopeering... Press [X] key to disable... ' VAR_TMP;
+		  echo "Set autopeering (default: $ca$VAR_DEFAULT$xx):"; echo "Press [Enter] to use default value:"
+		else
+		  echo "Set autopeering (config: $ca$VAR_SHIMMER_HORNET_AUTOPEERING$xx)"; echo "Press [Enter] to use existing config:"
+		fi
+		read -r -p '> Press [E] to enable Autopeering... Press [X] key to disable... ' VAR_TMP;
 		if [ -n "$VAR_TMP" ]; then
 		  VAR_SHIMMER_HORNET_AUTOPEERING=$VAR_TMP
-		  if  [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'a' ] || [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'A' ]; then
+		  if  [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'e' ] || [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'E' ]; then
 		    VAR_SHIMMER_HORNET_AUTOPEERING='true'
 		  else
 		    VAR_SHIMMER_HORNET_AUTOPEERING='false'
-		  fi
+		fi
 		elif [ -z "$VAR_SHIMMER_HORNET_AUTOPEERING" ]; then VAR_SHIMMER_HORNET_AUTOPEERING=$VAR_DEFAULT; fi
 
-		if  [ "$VAR_SHIMMER_HORNET_AUTOPEERING" ]; then
+		if  [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'true'  ]; then
 		  echo "$gn""Set autopeering: $VAR_SHIMMER_HORNET_AUTOPEERING""$xx"
 		else
 		  echo "$rd""Set autopeering: $VAR_SHIMMER_HORNET_AUTOPEERING""$xx"
+		fi
+
+		if [ "$VAR_SHIMMER_HORNET_AUTOPEERING" = 'false' ]; then
+		  echo ''
+		  VAR_DEFAULT_STATIC_NEIGHBORS=''
+		  VAR_SHIMMER_HORNET_STATIC_NEIGHBORS=$(cat .env 2>/dev/null | grep HORNET_STATIC_NEIGHBORS= | cut -d '=' -f 2)
+			
+		  if [ -n "$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS" ]; then
+		    echo "Set static neighbor(s):"
+		    echo "(config: static neighbor(s):"
+		    echo "$ca""$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS""$xx" | tr ',' '\n'
+		    echo ')'
+		    echo ''
+		    echo "Press [Enter] to confirm the above static neighbors or enter new ones (alias:multiAddress,):"
+		    read -r STATIC_NEIGHBORS_INPUT
+		  else
+		    echo "Set static neighbor(s):"
+		    echo "No static neighbors configured. Please enter static neighbors (alias:multiAddress,):"
+		    read -r STATIC_NEIGHBORS_INPUT
+		  fi
+
+		  STATIC_NEIGHBORS_INPUT=$(echo "$STATIC_NEIGHBORS_INPUT" | tr -d ' ')
+		  if [ -n "$STATIC_NEIGHBORS_INPUT" ]; then
+		  VAR_SHIMMER_HORNET_STATIC_NEIGHBORS=$STATIC_NEIGHBORS_INPUT
+		  elif [ -z "$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS" ]; then
+		    VAR_SHIMMER_HORNET_STATIC_NEIGHBORS=$VAR_DEFAULT_STATIC_NEIGHBORS
+		  fi
+		  if [ -n "$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS" ]; then
+		    echo ''
+		    echo "New static neighbor(s):"
+		    echo "$gn""$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS""$xx" | tr ',' '\n'
+		  fi
 		fi
 
 		echo ''
@@ -3500,6 +3573,7 @@ ShimmerHornet() {
 		echo "HORNET_HTTPS_PORT=$VAR_SHIMMER_HORNET_HTTPS_PORT" >> .env
 		echo "HORNET_GOSSIP_PORT=15600" >> .env
 		echo "HORNET_AUTOPEERING_ENABLED=$VAR_SHIMMER_HORNET_AUTOPEERING" >> .env
+		echo "HORNET_STATIC_NEIGHBORS=$VAR_SHIMMER_HORNET_STATIC_NEIGHBORS" >> .env
 		echo "HORNET_AUTOPEERING_PORT=14626" >> .env
 		echo "RESTAPI_SALT=$VAR_SALT" >> .env
 

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -2649,7 +2649,7 @@ IotaHornet() {
 		  echo "Set autopeering (config: $ca$VAR_IOTA_HORNET_AUTOPEERING$xx)"; echo "Press [Enter] to use existing config:"
 		fi
 		read -r -p '> Press [E] to enable Autopeering... Press [X] key to disable... ' VAR_TMP;
-        if [ -n "$VAR_TMP" ]; then
+		if [ -n "$VAR_TMP" ]; then
 		  VAR_IOTA_HORNET_AUTOPEERING=$VAR_TMP
 		  if  [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'e' ] || [ "$VAR_IOTA_HORNET_AUTOPEERING" = 'E' ]; then
 		    VAR_IOTA_HORNET_AUTOPEERING='true'

--- a/shimmer-hornet/docker-compose.yml
+++ b/shimmer-hornet/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "${HORNET_DATA_DIR:-./data}/config/config-${HORNET_NETWORK:-mainnet}.json:/app/config/config.json:ro"
+      - "${HORNET_DATA_DIR:-./data}/config/peering-${HORNET_NETWORK:-mainnet}.json:/app/config/peering.json"
       - "${HORNET_DATA_DIR:-./data}/storage/${HORNET_NETWORK:-mainnet}:/app/storage"
       - "${HORNET_DATA_DIR:-./data}/snapshots/${HORNET_NETWORK:-mainnet}:/app/snapshots"
       - "${HORNET_DATA_DIR:-./data}/p2pstore/${HORNET_NETWORK:-mainnet}:/app/p2pstore"

--- a/shimmer-hornet/prepare_docker.sh
+++ b/shimmer-hornet/prepare_docker.sh
@@ -12,6 +12,9 @@ dataDir="${HORNET_DATA_DIR:-$scriptDir/data}"
 configFilenameInContainer="config.json"
 configFilename="config-${HORNET_NETWORK:-mainnet}.json"
 configPath="${dataDir}/config/${configFilename}"
+peeringFilenameInContainer="peering.json"
+peeringFilename="peering-${HORNET_NETWORK:-mainnet}.json"
+peeringFilePath="${dataDir}/config/${peeringFilename}"
 
 validate_ssl_config "HORNET_SSL_CERT" "HORNET_SSL_KEY"
 copy_common_assets
@@ -66,6 +69,7 @@ set_config_if_present_in_env "${configPath}" "HORNET_PRUNING_MAX_MILESTONES_TO_K
 if [ ! -z "${HORNET_PRUNING_MAX_MILESTONES_TO_KEEP}" ]; then
   set_config "${configPath}" ".pruning.milestones.enabled" "true"
 fi
+generate_peering_json "$peeringFilePath" "${HORNET_STATIC_NEIGHBORS:-""}"
 rm -f "${tmp}"
 
 echo "Finished"


### PR DESCRIPTION
This improved version offers a more intuitive approach to managing autopeering and configuring static neighbors. 
To keep autopeering activated, users can simply press "E"(enable) and Enter. 
To disable autopeering, users need pressing the "X" key and than can enter the static neighbors. Also possible later with editing the .env. The peers are saved in the .env and using the format `alias:multiAddress, ...`.

When running prepare_docker.sh, the script extracts the static peers from the .env file and converts it to the peering.json format and also handles spaces and the absence of an alias. This file is stored in the specified folder to ensure smooth integration into the networks.
